### PR TITLE
Minor typo 'Pease Wait'

### DIFF
--- a/pages/new-step-searching.vue
+++ b/pages/new-step-searching.vue
@@ -23,7 +23,7 @@
     </section>
     <section :id='$style.body'>
       <img src="~/assets/img/loading.png">
-      <h3>Pease wait...</h3>
+      <h3>Please wait - Finding your controller...</h3>
       <small>Probing {{ retries }} / 5</small>
     </section>
   </section>


### PR DESCRIPTION
This is a minor typo/aesthetic improvement for the "Please Wait" message shown while the controller is located.